### PR TITLE
Pick a random rack instead of default-rack as the first rack

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/client/RackawareEnsemblePlacementPolicy.java
@@ -457,7 +457,8 @@ public class RackawareEnsemblePlacementPolicy implements EnsemblePlacementPolicy
                 return addrs;
             }
             // pick nodes by racks, to ensure there is at least two racks per write quorum.
-            for (int i = 0; i < ensembleSize; i++) {
+            prevNode = selectRandom(1, excludeNodes, ensemble).get(0);
+            for (int i = 1; i < ensembleSize; i++) {
                 String curRack;
                 if (null == prevNode) {
                     if (null == localNode) {


### PR DESCRIPTION
Problem: If there are more than 1 rack configured, we always try to pick the first bookie from "default-rack". If this rack is not there, we log warning "fallback to choose bookie randomly from the cluster" and end up choosing a random bookie. This will also overload bookies in default-rack, since we always pick the first bookie from this rack and choose the remaining bookies from remaining racks(if more than 2 racks exists). 

Solution: Pick a random rack from the available rack as our first rack and iterate through the remaining ones to pick the rest.
