### PR TITLE
Upgrade to RocksDB-5.3 to do range delete to clean bookie index

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>4.9.0</version>
+      <version>5.3.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorage.java
@@ -119,6 +119,8 @@ public interface KeyValueStorage extends Closeable {
 
         void remove(byte[] key);
 
+        void deleteRange(byte[] beginKey, byte[] endKey);
+
         void clear();
 
         void flush() throws IOException;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/KeyValueStorageRocksDB.java
@@ -396,6 +396,11 @@ public class KeyValueStorageRocksDB implements KeyValueStorage {
         }
 
         @Override
+        public void deleteRange(byte[] beginKey, byte[] endKey) {
+            writeBatch.deleteRange(beginKey, endKey);
+        }
+
+        @Override
         public void flush() throws IOException {
             try {
                 db.write(Sync, writeBatch);


### PR DESCRIPTION
In recent release of RocksDB-5.3, a new option feature to delete a range of key in one shot was added to the RocksJNI bindings (https://github.com/facebook/rocksdb/commit/5f65dc877806f8d60d64144ddee9023b178c2d50). The feature was already there in C++ API since 5.0.

Doing delete range when cleaning up the bookie rocksdb index is a lot more efficient, since it can replace the current behavior:
  1. Find what was the 1st entry in the ledger (involves using iterators that can be slow on big DBs)
  2. Find what was the last entry in the ledger
  

with: 
   1. Delete the range of keys for a single ledger (ledgerId, 0) --> (ledgerId, MAX_LONG) in one single operation

cc: @msb-at-yahoo

