### PR TITLE
Support DbLedgerStorage in LedgerCmd to get list of logger files for a given ledgerId

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ArrayUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ArrayUtil.java
@@ -7,13 +7,13 @@ import io.netty.util.internal.PlatformDependent;
 /**
  * Utility to serialize/deserialize longs into byte arrays
  */
-class ArrayUtil {
+public class ArrayUtil {
 
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
     private static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
-    static long getLong(byte[] array, int index) {
+    public static long getLong(byte[] array, int index) {
         if (HAS_UNSAFE && UNALIGNED) {
             long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Long.reverseBytes(v);
@@ -29,7 +29,7 @@ class ArrayUtil {
                 (long) array[index + 7] & 0xff;
     }
 
-    static void setLong(byte[] array, int index, long value) {
+    public static void setLong(byte[] array, int index, long value) {
         if (HAS_UNSAFE && UNALIGNED) {
             PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Long.reverseBytes(value));
         } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ArrayUtil.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/bookie/storage/ldb/ArrayUtil.java
@@ -7,13 +7,13 @@ import io.netty.util.internal.PlatformDependent;
 /**
  * Utility to serialize/deserialize longs into byte arrays
  */
-public class ArrayUtil {
+class ArrayUtil {
 
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
     private static final boolean HAS_UNSAFE = PlatformDependent.hasUnsafe();
     private static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
-    public static long getLong(byte[] array, int index) {
+    static long getLong(byte[] array, int index) {
         if (HAS_UNSAFE && UNALIGNED) {
             long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Long.reverseBytes(v);
@@ -29,7 +29,7 @@ public class ArrayUtil {
                 (long) array[index + 7] & 0xff;
     }
 
-    public static void setLong(byte[] array, int index, long value) {
+    static void setLong(byte[] array, int index, long value) {
         if (HAS_UNSAFE && UNALIGNED) {
             PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Long.reverseBytes(value));
         } else {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
@@ -46,6 +46,7 @@ public class LedgerCmdTest extends BookKeeperClusterTestCase {
         super(1);
         baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         baseConf.setGcWaitTime(60000);
+        baseConf.setFlushInterval(1);
     }
 
     
@@ -59,7 +60,6 @@ public class LedgerCmdTest extends BookKeeperClusterTestCase {
         LOG.info("Create ledger and add entries to it");
         LedgerHandle lh1 = createLedgerWithEntries(bk, 10);
         
-        Thread.sleep(1000); // sleep to flush entries to logger file
         String[] argv = new String[] { "ledger", Long.toString(lh1.getId()) };
         final ServerConfiguration conf = bsConfs.get(0);
         conf.setUseHostNameAsBookieID(true);

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/LedgerCmdTest.java
@@ -1,0 +1,96 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.bookkeeper.client;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.bookkeeper.bookie.BookieShell;
+import org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage;
+import org.apache.bookkeeper.client.AsyncCallback.AddCallback;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.test.BookKeeperClusterTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.Assert;
+
+public class LedgerCmdTest extends BookKeeperClusterTestCase {
+
+    private final static Logger LOG = LoggerFactory.getLogger(LedgerCmdTest.class);
+    private DigestType digestType = DigestType.CRC32;
+    private static final String PASSWORD = "testPasswd";
+
+    public LedgerCmdTest() {
+        super(1);
+        baseConf.setLedgerStorageClass(DbLedgerStorage.class.getName());
+        baseConf.setGcWaitTime(60000);
+    }
+
+    
+    /**
+     * list of entry logger files that contains given ledgerId
+     */
+    @Test
+    public void testLedgerDbStorageCmd() throws Exception {
+        
+        BookKeeper bk = new BookKeeper(baseClientConf, zkc);
+        LOG.info("Create ledger and add entries to it");
+        LedgerHandle lh1 = createLedgerWithEntries(bk, 10);
+        
+        Thread.sleep(1000); // sleep to flush entries to logger file
+        String[] argv = new String[] { "ledger", Long.toString(lh1.getId()) };
+        final ServerConfiguration conf = bsConfs.get(0);
+        conf.setUseHostNameAsBookieID(true);
+
+        BookieShell bkShell = new BookieShell();
+        bkShell.setConf(conf);
+        
+        Assert.assertEquals("Failed to return exit code!", 0, bkShell.run(argv));
+
+    }
+
+    private LedgerHandle createLedgerWithEntries(BookKeeper bk, int numOfEntries) throws Exception {
+        LedgerHandle lh = bk.createLedger(1, 1, digestType, PASSWORD.getBytes());
+        final AtomicInteger rc = new AtomicInteger(BKException.Code.OK);
+        final CountDownLatch latch = new CountDownLatch(numOfEntries);
+
+        final AddCallback cb = new AddCallback() {
+            public void addComplete(int rccb, LedgerHandle lh, long entryId, Object ctx) {
+                rc.compareAndSet(BKException.Code.OK, rccb);
+                latch.countDown();
+            }
+        };
+        for (int i = 0; i < numOfEntries; i++) {
+            lh.asyncAddEntry(("foobar" + i).getBytes(), cb, null);
+        }
+        if (!latch.await(30, TimeUnit.SECONDS)) {
+            throw new Exception("Entries took too long to add");
+        }
+        if (rc.get() != BKException.Code.OK) {
+            throw BKException.create(rc.get());
+        }
+        return lh;
+    }
+}


### PR DESCRIPTION
### Motivation

In certain conditions client may require to get list of entryLog files that contain given ledgerId for specific auditing or cleanup. Right now, `LedgerCmd` under `BookieShell` gives similar information but it doesn't support DbLedgerStorage so, added support for DbLedgerStorage to LedgerCmd.

### Modifications
Add DbLedgerStorage support under `BookieShell.LedgerCmd`.