### PR TITLE
Fix: comment out overriden registerFailedValue method for Prometheus logger

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
@@ -60,7 +60,7 @@ public class PrometheusOpStatsLogger implements OpStatsLogger {
         success.observe(value);
     }
 
-    @Override
+    //@Override : uncomment once this method added into parent
     public void registerFailedValue(long value) {
         fail.observe(value);
     }


### PR DESCRIPTION
Right now, [OpStatsLogger](https://github.com/yahoo/bookkeeper/blob/yahoo-4.3/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/OpStatsLogger.java) in yahoo-4.3 doesn't have `registerFailedValue`. So, comment out in `PrometheusOpStatsLogger` for now until we fetch `registerFailedValue` changes from master.