### PR TITLE
Fix DoubleByteBuf readableBytes()

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
@@ -61,6 +61,7 @@ public class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
         // outside of DoubleByteBuf scope
         buf.b1 = b1.retain();
         buf.b2 = b2.retain();
+        buf.setIndex(0, b1.readableBytes() + b2.readableBytes());
         return buf;
     }
 
@@ -99,11 +100,6 @@ public class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public int capacity() {
         return b1.capacity() + b2.capacity();
-    }
-
-    @Override
-    public int readableBytes() {
-        return b1.readableBytes() + b2.readableBytes();
     }
 
     @Override

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/util/DoubleByteBufTest.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 
 public class DoubleByteBufTest {
@@ -100,5 +101,29 @@ public class DoubleByteBufTest {
         ByteBuf b = DoubleByteBuf.get(b1, b2);
 
         assertEquals(ByteBuffer.wrap(new byte[] { 1, 2, 3, 4 }), b.nioBuffer());
+    }
+
+    /**
+     * Verify that readableBytes() returns writerIndex - readerIndex. In this case writerIndex is the end of the buffer
+     * and readerIndex is increased by 64.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testReadableBytes() throws Exception {
+        ByteBuf b1 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
+        b1.writerIndex(b1.capacity());
+        ByteBuf b2 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
+        b2.writerIndex(b2.capacity());
+        ByteBuf buf = DoubleByteBuf.get(b1, b2);
+
+        assertEquals(buf.readerIndex(), 0);
+        assertEquals(buf.writerIndex(), 256);
+        assertEquals(buf.readableBytes(), 256);
+
+        for (int i = 0; i < 4; ++i) {
+            buf.skipBytes(64);
+            assertEquals(buf.readableBytes(), 256 - 64 * (i + 1));
+        }
     }
 }


### PR DESCRIPTION
Backport a fix to `DoubleByteBuf` that was already applied to apache/incubator-pulsar#447

This is required to upgrade to Netty 4.1