### PR TITLE
Upgrade to Netty-4.1

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.36.Final</version>
+      <version>4.1.14.Final</version>
     </dependency>
     <dependency>
       <groupId>com.carrotsearch</groupId>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/DoubleByteBuf.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
@@ -276,6 +277,56 @@ public class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
As a pre-condition to update Pulsar to use Netty-4.1, we need to have Bookkeeper to upgrade as well. Latest BK release 4.5.0 is already on Netty 4.1.

