### PR TITLE
Add sanity check in GC to prevent active ledger deletion

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -60,6 +60,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.6.4</version>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/CleanupLedgerManager.java
@@ -144,6 +144,20 @@ public class CleanupLedgerManager implements LedgerManager {
     }
 
     @Override
+    public void existLedgerMetadata(final long ledgerId, final GenericCallback<Boolean> callback) {
+        closeLock.readLock().lock();
+        try {
+            if (closed) {
+                callback.operationComplete(BKException.Code.ClientClosedException, false);
+                return;
+            }
+            underlying.existLedgerMetadata(ledgerId, new CleanupGenericCallback<Boolean>(callback));
+        } finally {
+            closeLock.readLock().unlock();
+        }
+    }
+    
+    @Override
     public void writeLedgerMetadata(long ledgerId, LedgerMetadata metadata,
                                     GenericCallback<Void> cb) {
         closeLock.readLock().lock();

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LedgerManager.java
@@ -90,6 +90,20 @@ public interface LedgerManager extends Closeable {
     public void readLedgerMetadata(long ledgerId, GenericCallback<LedgerMetadata> readCb);
 
     /**
+     * Check ledger metadata exists for a specified ledger.
+     *
+     * @param ledgerId
+     *          Ledger Id
+     * @param readCb
+     *          Callback when read ledger metadata. Return code:<ul>
+     *          <li>{@link BKException.Code.OK} if success</li>
+     *          <li>{@link BKException.Code.NoSuchLedgerExistsException} if ledger not exist</li>
+     *          <li>{@link BKException.Code.ZKException} for other issue</li>
+     *          </ul>
+     */
+    void existLedgerMetadata(long ledgerId, GenericCallback<Boolean> callback);
+    
+    /**
      * Write ledger metadata.
      *
      * @param ledgerId

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/bookie/CompactionTest.java
@@ -528,6 +528,10 @@ public class CompactionTest extends BookKeeperClusterTestCase {
                         }
                     };
                  }
+                @Override
+                public void existLedgerMetadata(long ledgerId, GenericCallback<Boolean> callback) {
+                    unsupported();
+                }
             };
         }
 


### PR DESCRIPTION
### Motivation

Sometimes, due to unexpected bugs in GC, GC deletes active ledgers (ledger metadata still exist in ZK) from the bookie and it results into the data-loss.

We have seen this scenario multiple times: 
(1) [Lexicographical sorting at ledgerManager](https://github.com/yahoo/bookkeeper/commit/604d7a9dd14e2236d27a4662b70f671bf7dc3d9e)
(2) Recently we have seen that [LongHierarchicalLedgerManager](https://github.com/yahoo/bookkeeper/blob/yahoo-4.3/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java) doesn't handle ledger directory traversing if we manually cleans up empty directory which doesn't contain any children.
eg:
We implemented a cron job to delete ledger directory from zookeeper, when it does not contain any children in zookeeper. e.g: `/ledgers/000/0000/0042/0003`
In the above sequence, after processing 0001 and 0002 nodes, when LongHierarchicalLedgerManager iterator sees the next node(0003) does not exist, it assumes no other nodes starting from 0003 till 9999 exists under /ledgers/000/0000/0042. This triggers bookie to delete any ledgers from 0004 onwards present in that bookie.

So, we have seen data loss multiple times which can be prevented if GC can perform a sanity check before cleaning ledger from the bookie.

### Modifications

Add sanity check before cleaning up the ledger.

### Result

It can prevent possible data loss due to any bug in GC.