### PR TITLE
YBK-183: Garbage collector deletes active ledgers present in zookeeper

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
@@ -230,7 +230,8 @@ class LongHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
                 }
             }
             String curLNode = curLevelNodes.get(level);
-            if (curLNode != null) {
+            // If no level 3 nodes are present then go to the next node in level 2
+            if (curLNode != null || moveToNext(level)) {
                 // Traverse down through levels 0-3
                 // The nextRange becomes a listing of the children
                 // in the level4 directory.


### PR DESCRIPTION
When all level 3 nodes are deleted from a given level 2 node, the hasNext returns null which compels the bookkeeper to incorrectly GC the ledgers

Based on the position of the level 2 node either of the two can happen:-
a. If the level2 node is the **first** level2 node scanned (smallest number) then  the bookkeeper GCs all nodes herewith - Fixed in this PR

b. if level2 node is in the **middle** (not the first) the bookkeeper throws an exception - and GC activity stops altogether and those ledgers are never deleted - Needs to be analyzed and fixed


I am able to reproduce these scenarios manually - will see if I can add unit tests

@revans2 