### PR TITLE
ISSUE #1078: use CachingStatsProvider underly PrometheusMetricsProvider

### DIFF
--- a/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/pom.xml
@@ -70,5 +70,12 @@
       <version>${guava.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusCounter.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusCounter.java
@@ -25,7 +25,8 @@ public class PrometheusCounter implements Counter {
     private final Gauge gauge;
 
     public PrometheusCounter(CollectorRegistry registry, String name) {
-        this.gauge = Gauge.build().name(Collector.sanitizeMetricName(name)).help("-").create().register(registry);
+        this.gauge = PrometheusUtil.safeRegister(registry,
+                Gauge.build().name(Collector.sanitizeMetricName(name)).help("-").create());
     }
 
     @Override

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusOpStatsLogger.java
@@ -28,17 +28,18 @@ public class PrometheusOpStatsLogger implements OpStatsLogger {
     private final Summary.Child fail;
 
     public PrometheusOpStatsLogger(CollectorRegistry registry, String name) {
-        this.summary = Summary.build().name(name).help("-") //
-                .quantile(0.50, 0.01) //
-                .quantile(0.75, 0.01) //
-                .quantile(0.95, 0.01) //
-                .quantile(0.99, 0.01) //
-                .quantile(0.999, 0.01) //
-                .quantile(0.9999, 0.01) //
-                .quantile(1.0, 0.01) //
-                .maxAgeSeconds(60) //
-                .labelNames("success") //
-                .create().register(registry);
+        this.summary = PrometheusUtil.safeRegister(registry,
+                Summary.build().name(name).help("-") //
+                        .quantile(0.50, 0.01) //
+                        .quantile(0.75, 0.01) //
+                        .quantile(0.95, 0.01) //
+                        .quantile(0.99, 0.01) //
+                        .quantile(0.999, 0.01) //
+                        .quantile(0.9999, 0.01) //
+                        .quantile(1.0, 0.01) //
+                        .maxAgeSeconds(60) //
+                        .labelNames("success") //
+                        .create());
 
         this.success = summary.labels("true");
         this.fail = summary.labels("false");

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusStatsLogger.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusStatsLogger.java
@@ -43,8 +43,8 @@ public class PrometheusStatsLogger implements StatsLogger {
 
     @Override
     public <T extends Number> void registerGauge(String name, Gauge<T> gauge) {
-        io.prometheus.client.Gauge.build().name(completeName(name)).help("-").create()
-                .setChild(new io.prometheus.client.Gauge.Child() {
+        PrometheusUtil.safeRegister(registry, io.prometheus.client.Gauge.build().name(completeName(name)).help("-")
+                .create().setChild(new io.prometheus.client.Gauge.Child() {
                     @Override
                     public double get() {
                         Number value = null;
@@ -59,7 +59,7 @@ public class PrometheusStatsLogger implements StatsLogger {
                         }
                         return value.doubleValue();
                     }
-                }).register(registry);
+                }));
     }
 
     @Override

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Container for Prometheus utility methods.
+ *
+ */
+public class PrometheusUtil {
+
+    private static final Field collectorsMapField;
+    private static final Method collectorsNamesMethod;
+
+    static {
+        try {
+            collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
+            collectorsMapField.setAccessible(true);
+
+            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", String.class);
+            collectorsNamesMethod.setAccessible(true);
+
+        } catch (NoSuchFieldException | SecurityException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Collector> T safeRegister(CollectorRegistry registry, T collector) {
+        try {
+            registry.register(collector);
+            return collector;
+        } catch (IllegalArgumentException e) {
+            // Collector is already registered. Return the existing instance
+            try {
+                Map<String, Collector> collectorsMap = (Map<String, Collector>) collectorsMapField.get(registry);
+                List<String> collectorNames = (List<String>) collectorsNamesMethod.invoke(registry, collector);
+                return (T) collectorsMap.get(collectorNames.get(0));
+
+            } catch (IllegalArgumentException | IllegalAccessException | InvocationTargetException e1) {
+                throw new RuntimeException(e1);
+            }
+        }
+    }
+}

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/main/java/org/apache/bookkeeper/stats/PrometheusUtil.java
@@ -39,7 +39,7 @@ public class PrometheusUtil {
             collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
             collectorsMapField.setAccessible(true);
 
-            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", String.class);
+            collectorsNamesMethod = CollectorRegistry.class.getDeclaredMethod("collectorNames", Collector.class);
             collectorsNamesMethod.setAccessible(true);
 
         } catch (NoSuchFieldException | SecurityException | NoSuchMethodException e) {

--- a/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
+++ b/bookkeeper-stats-providers/prometheus-metrics-provider/src/test/java/org/apache/bookkeeper/stats/prometheus/TestPrometheusMetricsProvider.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats.prometheus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.bookkeeper.stats.Counter;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.bookkeeper.stats.PrometheusCounter;
+import org.apache.bookkeeper.stats.PrometheusMetricsProvider;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.junit.Test;
+
+public class TestPrometheusMetricsProvider {
+
+    private final CollectorRegistry registry = new CollectorRegistry();
+
+    @Test
+    public void testCache() {
+        PrometheusMetricsProvider provider = new PrometheusMetricsProvider();
+
+        StatsLogger statsLogger =  provider.getStatsLogger("test");
+
+        OpStatsLogger opStatsLogger1 = statsLogger.getOpStatsLogger("optest");
+        OpStatsLogger opStatsLogger2 = statsLogger.getOpStatsLogger("optest");
+        assertSame(opStatsLogger1, opStatsLogger2);
+
+        Counter counter1 = statsLogger.getCounter("countertest");
+        Counter counter2 = statsLogger.getCounter("countertest");
+        assertSame(counter1, counter2);
+
+        StatsLogger scope1 = statsLogger.scope("scopetest");
+        StatsLogger scope2 = statsLogger.scope("scopetest");
+        assertSame(scope1, scope2);
+    }
+
+    @Test
+    public void testCounter() {
+        PrometheusCounter counter = new PrometheusCounter(registry, "testcounter");
+        long value = counter.get();
+        assertEquals(0L, value);
+        counter.inc();
+        assertEquals(1L, counter.get().longValue());
+        counter.dec();
+        assertEquals(0L, counter.get().longValue());
+        counter.add(3);
+        assertEquals(3L, counter.get().longValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTwoCounters() throws Exception {
+        PrometheusCounter counter1 = new PrometheusCounter(registry, "testcounter");
+        PrometheusCounter counter2 = new PrometheusCounter(registry, "testcounter");
+        Field collectorsMapField = CollectorRegistry.class.getDeclaredField("namesToCollectors");
+        collectorsMapField.setAccessible(true);
+        Map<String, Collector> collectorMap = (Map<String, Collector>) collectorsMapField.get(registry);
+        assertEquals(1, collectorMap.size());
+    }
+
+}

--- a/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/CachingStatsLogger.java
+++ b/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/CachingStatsLogger.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A {@code StatsLogger} that caches the stats objects created by other {@code StatsLogger}.
+ */
+public class CachingStatsLogger implements StatsLogger {
+
+    protected final StatsLogger underlying;
+    protected final ConcurrentMap<String, Counter> counters;
+    protected final ConcurrentMap<String, OpStatsLogger> opStatsLoggers;
+    protected final ConcurrentMap<String, StatsLogger> scopeStatsLoggers;
+
+    public CachingStatsLogger(StatsLogger statsLogger) {
+        this.underlying = statsLogger;
+        this.counters = new ConcurrentHashMap<String, Counter>();
+        this.opStatsLoggers = new ConcurrentHashMap<String, OpStatsLogger>();
+        this.scopeStatsLoggers = new ConcurrentHashMap<String, StatsLogger>();
+    }
+
+    @Override
+    public int hashCode() {
+        return underlying.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CachingStatsLogger)) {
+            return false;
+        }
+        CachingStatsLogger another = (CachingStatsLogger) obj;
+        return underlying.equals(another.underlying);
+    }
+
+    @Override
+    public String toString() {
+        return underlying.toString();
+    }
+
+    @Override
+    public OpStatsLogger getOpStatsLogger(String name) {
+        OpStatsLogger opStatsLogger = opStatsLoggers.get(name);
+        if (null == opStatsLogger) {
+            OpStatsLogger newOpStatsLogger = underlying.getOpStatsLogger(name);
+            OpStatsLogger oldOpStatsLogger = opStatsLoggers.putIfAbsent(name, newOpStatsLogger);
+            opStatsLogger = (null == oldOpStatsLogger) ? newOpStatsLogger : oldOpStatsLogger;
+        }
+        return opStatsLogger;
+    }
+
+    @Override
+    public Counter getCounter(String name) {
+        Counter counter = counters.get(name);
+        if (null == counter) {
+            Counter newCounter = underlying.getCounter(name);
+            Counter oldCounter = counters.putIfAbsent(name, newCounter);
+            counter = (null == oldCounter) ? newCounter : oldCounter;
+        }
+        return counter;
+    }
+
+    @Override
+    public <T extends Number> void registerGauge(String name, Gauge<T> gauge) {
+        underlying.registerGauge(name, gauge);
+    }
+
+    @Override
+    public StatsLogger scope(String name) {
+        StatsLogger statsLogger = scopeStatsLoggers.get(name);
+        if (null == statsLogger) {
+            StatsLogger newStatsLogger = new CachingStatsLogger(underlying.scope(name));
+            StatsLogger oldStatsLogger = scopeStatsLoggers.putIfAbsent(name, newStatsLogger);
+            statsLogger = (null == oldStatsLogger) ? newStatsLogger : oldStatsLogger;
+        }
+        return statsLogger;
+    }
+
+}

--- a/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/CachingStatsProvider.java
+++ b/bookkeeper-stats/src/main/java/org/apache/bookkeeper/stats/CachingStatsProvider.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.bookkeeper.stats;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * A {@code CachingStatsProvider} adds the caching functionality to an existing {@code StatsProvider}.
+ *
+ * <p>The stats provider will cache the stats objects created by the other {@code StatsProvider} to allow
+ * the reusability of stats objects and avoid creating a lot of stats objects.
+ */
+public class CachingStatsProvider implements StatsProvider {
+
+    protected final StatsProvider underlying;
+    protected final ConcurrentMap<String, StatsLogger> statsLoggers;
+
+    public CachingStatsProvider(StatsProvider provider) {
+        this.underlying = provider;
+        this.statsLoggers = new ConcurrentHashMap<String, StatsLogger>();
+    }
+
+    @Override
+    public void start(Configuration conf) {
+        this.underlying.start(conf);
+    }
+
+    @Override
+    public void stop() {
+        this.underlying.stop();
+    }
+
+    @Override
+    public StatsLogger getStatsLogger(String scope) {
+        StatsLogger statsLogger = statsLoggers.get(scope);
+        if (null == statsLogger) {
+            StatsLogger newStatsLogger =
+                    new CachingStatsLogger(underlying.getStatsLogger(scope));
+            StatsLogger oldStatsLogger = statsLoggers.putIfAbsent(scope, newStatsLogger);
+            statsLogger = (null == oldStatsLogger) ? newStatsLogger : oldStatsLogger;
+        }
+        return statsLogger;
+    }
+}


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add CachingStatsProvider to wrapper PrometheusMetricsProvider;
- add test verify the cache.

Master Issue: #1078

Author: Jia Zhai <zhaijia@apache.org>

Reviewers: Sijie Guo <sijie@apache.org>, Matteo Merli <mmerli@apache.org>

This closes #1081 from jiazhai/issue-1078, closes #1078