### PR TITLE
Attempting to fix exception when missing level2 node is in the middle

### DIFF
--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/meta/LongHierarchicalLedgerManager.java
@@ -333,11 +333,19 @@ class LongHierarchicalLedgerManager extends AbstractHierarchicalLedgerManager {
         }
 
         private LedgerRange getLedgerRangeByLevel(List<String> curLevelNodes) throws IOException {
+            if (curLevelNodes.size() < 4) {
+                return  null;
+            }
+            
             String level0 = curLevelNodes.get(0);
             String level1 = curLevelNodes.get(1);
             String level2 = curLevelNodes.get(2);
             String level3 = curLevelNodes.get(3);
-
+            
+            if (level0 == null || level1 == null || level2 == null || level3 == null) {
+                return  null;
+            }
+            
             StringBuilder nodeBuilder = new StringBuilder();
             nodeBuilder.append(ledgerRootPath).append("/").append(level0).append("/").append(level1).append("/")
                     .append(level2).append("/").append(level3);


### PR DESCRIPTION
@revans2  - This is a possible fix for issue#2 (#17 )
I have not tested this PR - short on time 
But according to the stack trace this should be the fix 

=======

20:33:56.923 [GarbageCollectorThread-3-1-EventThread] ERROR org.apache.bookkeeper.util.ZkUtils   - Error polling ZK for the available nodes: 
org.apache.zookeeper.KeeperException$NoNodeException: KeeperErrorCode = NoNode for /ledgers/000/0000/0046/null
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:111) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:51) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.bookkeeper.util.ZkUtils$4$1.processResult(ZkUtils.java:220) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.zookeeper.ClientCnxn$EventThread.processEvent(ClientCnxn.java:584) [zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.ClientCnxn$EventThread.run(ClientCnxn.java:498) [zookeeper-3.4.6.jar:3.4.6-1569965]
20:33:56.923 [GarbageCollectorThread-3-1] WARN  o.a.b.b.ScanAndCompareGarbageCollector - Exception when iterating over the metadata {}
java.io.IOException: Error on getting children from node /ledgers/000/0000/0046/null
        at org.apache.bookkeeper.util.ZkUtils.getChildrenInSingleNode(ZkUtils.java:188) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.meta.LongHierarchicalLedgerManager$LongHierarchicalLedgerRangeIterator.getLedgerRangeByLevel(LongHierarchicalLedgerManager.java:362) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.meta.LongHierarchicalLedgerManager$LongHierarchicalLedgerRangeIterator.preload(LongHierarchicalLedgerManager.java:320) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.meta.LongHierarchicalLedgerManager$LongHierarchicalLedgerRangeIterator.hasNext(LongHierarchicalLedgerManager.java:330) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.meta.HierarchicalLedgerManager$HierarchicalLedgerRangeIterator.hasNext(HierarchicalLedgerManager.java:109) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.bookie.ScanAndCompareGarbageCollector.gc(ScanAndCompareGarbageCollector.java:124) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.bookie.GarbageCollectorThread.safeRun(GarbageCollectorThread.java:360) [bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at org.apache.bookkeeper.util.SafeRunnable.run(SafeRunnable.java:31) [bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_131]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_131]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) [netty-common-4.0.42.Final.jar:4.0.42.Final]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_131]
=======
